### PR TITLE
Implementacia Facebook oauth loginu.

### DIFF
--- a/__install/alter_users_01.sql
+++ b/__install/alter_users_01.sql
@@ -1,0 +1,2 @@
+alter table users add facebook_id varchar(64) default null;
+CREATE INDEX users_facebook_id_idx on users (facebook_id);

--- a/app/controllers/api/OauthProvider.php
+++ b/app/controllers/api/OauthProvider.php
@@ -20,7 +20,7 @@ class OauthProvider extends Controller
     try {
       $fbUser = $this->model->fbCheckUserLogin();
     } catch(\Exception $e) {
-      Session::setFlash($e->getMessage(), "danger",1);
+      Session::setFlash(getString('FACEBOOK_LOGIN_ERROR')." ".$e->getMessage(), "danger",1);
       Redirect::toURL('LOGIN');
     }
 
@@ -29,6 +29,7 @@ class OauthProvider extends Controller
     if ($fbUser['id']) {
       if ($userData = $user->getByFacebookId($fbUser['id'])) {
         $user->loginUser($userData);
+        Session::setFlash(getString('FACEBOOK_LOGIN_SUCCESS'), "success", 1); //not yet used - maybe sometimes
         redirect('/users');
       }
     }
@@ -40,11 +41,13 @@ class OauthProvider extends Controller
         $this->model->runQuery("UPDATE `users` SET updated_at = now(), facebook_id = :facebook_id WHERE user_id=:id", array("id" => $userData['user_id'], "facebook_id" => $fbUser['id']), "post");
 
         $user->loginUser($userData);
+
+        Session::setFlash(getString('FACEBOOK_LOGIN_SUCCESS'), "success", 1); //not yet used - maybe sometimes
         redirect('/users');
       }
     }
 
-    Session::setFlash("User not found.", "danger",1);
+    Session::setFlash(getString('FACEBOOK_LOGIN_ERROR')." User not found.", "danger",1);
     Redirect::toURL('LOGIN');
   }
 
@@ -53,13 +56,13 @@ class OauthProvider extends Controller
     try {
       $fbUser = $this->model->fbCheckUserLogin();
     } catch(\Exception $e) {
-      Session::setFlash($e->getMessage(), "danger",1);
+      Session::setFlash(getString('FACEBOOK_REGISTER_ERROR')." ".$e->getMessage(), "danger",1);
       Redirect::toURL('REGISTER');
     }
 
     // not enough data
     if (!$fbUser['email'] || !$fbUser['name']) {
-      Session::setFlash('Not enough data for registration.', "danger",1);
+      Session::setFlash(getString('FACEBOOK_REGISTER_ERROR')." Not enough data", "danger",1);
       Redirect::toURL('REGISTER');
     }
 
@@ -67,6 +70,7 @@ class OauthProvider extends Controller
     // check if user already exists
     if ($userData = $user->getByFacebookId($fbUser['id'])) {
       $user->loginUser($userData);
+      Session::setFlash(getString('FACEBOOK_REGISTER_SUCCESS'), "success", 1);
       redirect('/users');
     }
     if ($userData = $user->getByEmail($fbUser['email'])) {
@@ -74,6 +78,7 @@ class OauthProvider extends Controller
       $this->model->runQuery("UPDATE `users` SET updated_at = now(), facebook_id = :facebook_id WHERE user_id=:id", array("id" => $userData['user_id'], "facebook_id" => $fbUser['id']), "post");
 
       $user->loginUser($userData);
+      Session::setFlash(getString('FACEBOOK_REGISTER_SUCCESS'), "success", 1);
       redirect('/users');
     }
 
@@ -105,7 +110,7 @@ class OauthProvider extends Controller
 
     $user->loginUser($userData);
 
-    Session::setFlash(getString('REGISTRATION_SUCCESS'), "success", 1);
+    Session::setFlash(getString('FACEBOOK_REGISTER_SUCCESS'), "success", 1);
     redirect('/users/update');
   }
 
@@ -114,7 +119,7 @@ class OauthProvider extends Controller
     try {
       $fbUser = $this->model->fbCheckUserLogin();
     } catch(\Exception $e) {
-      Session::setFlash($e->getMessage(), "danger",1);
+      Session::setFlash(getString('FACEBOOK_CONNECT_ERROR')." ".$e->getMessage(), "danger",1);
       redirect('/users');
     }
     $user = new User();
@@ -123,7 +128,7 @@ class OauthProvider extends Controller
     if ($userData = $user->getByFacebookId($fbUser['id'])) {
       // if user exist and is diferent from logend user - then error
       if($userData['user_id'] != Session::get('user_id')) {
-        Session::setFlash("Cannot connect Facebook account. Facebook user already exists.", "danger",1);
+        Session::setFlash(getString('FACEBOOK_CONNECT_ERROR')." Facebook user already exists.", "danger",1);
         redirect('/users/update');
       }
     }
@@ -131,6 +136,7 @@ class OauthProvider extends Controller
     // update users facebook_id
     $this->model->runQuery("UPDATE `users` SET updated_at = now(), facebook_id = :facebook_id WHERE user_id=:id", array("id" => Session::get('user_id'), "facebook_id" => $fbUser['id']), "post");
 
+    Session::setFlash(getString('FACEBOOK_CONNECT_SUCCESS'), "success", 1);
     redirect('/users');
   }
 

--- a/app/controllers/api/OauthProvider.php
+++ b/app/controllers/api/OauthProvider.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace app\controllers\api;
+
+use app\model\User;
+use app\core\Controller;
+use app\core\Session;
+use app\helper\Redirect;
+
+class OauthProvider extends Controller
+{
+
+	public function __construct()
+  {
+    $this->model = $this->model("OauthProvider");
+  }
+
+  public function fb_login_callback()
+  {
+    try {
+      $fbUser = $this->model->fbCheckUserLogin();
+    } catch(\Exception $e) {
+      Session::setFlash($e->getMessage(), "danger",1);
+      Redirect::toURL('LOGIN');
+    }
+
+    $user = new User();
+    // search user by facebook id
+    if ($fbUser['id']) {
+      if ($userData = $user->getByFacebookId($fbUser['id'])) {
+        $user->loginUser($userData);
+        redirect('/users');
+      }
+    }
+
+    // try to look up user by facebook email
+    if ($fbUser['email']) {
+      if ($userData = $user->getByEmail($fbUser['email'])) {
+        // update user facebook_id
+        $this->model->runQuery("UPDATE `users` SET updated_at = now(), facebook_id = :facebook_id WHERE user_id=:id", array("id" => $userData['user_id'], "facebook_id" => $fbUser['id']), "post");
+
+        $user->loginUser($userData);
+        redirect('/users');
+      }
+    }
+
+    Session::setFlash("User not found.", "danger",1);
+    Redirect::toURL('LOGIN');
+  }
+
+  public function fb_register_callback()
+  {
+    try {
+      $fbUser = $this->model->fbCheckUserLogin();
+    } catch(\Exception $e) {
+      Session::setFlash($e->getMessage(), "danger",1);
+      Redirect::toURL('REGISTER');
+    }
+
+    // not enough data
+    if (!$fbUser['email'] || !$fbUser['name']) {
+      Session::setFlash('Not enough data for registration.', "danger",1);
+      Redirect::toURL('REGISTER');
+    }
+
+    $user = new User();
+    // check if user already exists
+    if ($userData = $user->getByFacebookId($fbUser['id'])) {
+      $user->loginUser($userData);
+      redirect('/users');
+    }
+    if ($userData = $user->getByEmail($fbUser['email'])) {
+      // update user facebook_id
+      $this->model->runQuery("UPDATE `users` SET updated_at = now(), facebook_id = :facebook_id WHERE user_id=:id", array("id" => $userData['user_id'], "facebook_id" => $fbUser['id']), "post");
+
+      $user->loginUser($userData);
+      redirect('/users');
+    }
+
+    // form registration pg_parameter_status
+    $userData['username'] = $fbUser['name'];
+    $userData['email'] = $fbUser['email'];
+    $userData['password'] = "no password";
+    $userData['facebook_id'] = $fbUser['id'];
+    //  guess firs/last name
+    $name = explode(" ", $fbUser['name'], 2);
+    $userData['first_name'] = $name[0];
+    $userData['last_name'] = $name[1];
+
+    //register
+    $this->model->runQuery("INSERT INTO users (username, first_name, last_name, email, password, country, role, facebook_id) VALUES(:username, :first_name, :last_name, :email, :password, :country, :role, :facebook_id)",
+     array(
+       "username" => $userData['username'],
+       "first_name" => $userData['first_name'],
+       "last_name" => $userData['last_name'],
+       "email" => $userData['email'],
+       "password" => $userData['password'],
+       "country" => COUNTRY_CODE,
+       "role" => 4,
+       "facebook_id" =>  $userData['facebook_id']
+     ), "post");
+
+    //refresh user
+    $userData = $user->getByFacebookId($userData['facebook_id']);
+
+    $user->loginUser($userData);
+
+    Session::setFlash(getString('REGISTRATION_SUCCESS'), "success", 1);
+    redirect('/users/update');
+  }
+
+  public function fb_connect_callback()
+  {
+    try {
+      $fbUser = $this->model->fbCheckUserLogin();
+    } catch(\Exception $e) {
+      Session::setFlash($e->getMessage(), "danger",1);
+      redirect('/users');
+    }
+    $user = new User();
+
+    // search user by facebook_id
+    if ($userData = $user->getByFacebookId($fbUser['id'])) {
+      // if user exist and is diferent from logend user - then error
+      if($userData['user_id'] != Session::get('user_id')) {
+        Session::setFlash("Cannot connect Facebook account. Facebook user already exists.", "danger",1);
+        redirect('/users/update');
+      }
+    }
+
+    // update users facebook_id
+    $this->model->runQuery("UPDATE `users` SET updated_at = now(), facebook_id = :facebook_id WHERE user_id=:id", array("id" => Session::get('user_id'), "facebook_id" => $fbUser['id']), "post");
+
+    redirect('/users');
+  }
+
+}

--- a/app/controllers/api/Users.php
+++ b/app/controllers/api/Users.php
@@ -17,6 +17,7 @@ class Users extends Controller
 
     public function logout()
     {
+      // funkcionality login/logout prenesene do vlastnych User metod
       $this->model->logoutUser();
     }
 
@@ -34,7 +35,9 @@ class Users extends Controller
                 }
 
                 if ( password_verify($mPass, $user['password']) ) {
+                    // funkcionalita log in tajk isto prenesena do vlastnej User metody
                     $this->model->loginUser($user);
+                    // zjednotil som "landing" stranky pre login/logout modalne aj kalsicke
                     redirect('/users');
                 } else {
                     Session::setFlash(getString('CREDENTIALS_NOT_MATCH'), "warning", 1);

--- a/app/controllers/api/Users.php
+++ b/app/controllers/api/Users.php
@@ -17,8 +17,7 @@ class Users extends Controller
 
     public function logout()
     {
-        Session::destroy();
-        Redirect::toURL("LOGIN");
+      $this->model->logoutUser();
     }
 
     public function login()
@@ -35,11 +34,7 @@ class Users extends Controller
                 }
 
                 if ( password_verify($mPass, $user['password']) ) {
-                    Session::set('user_id', $user['user_id']);
-                    Session::set('user_role', $user['role']);
-                    Session::set('user_country', $user['country']);
-                    Session::set('username', $user['username']);
-                    $this->model->runQuery("UPDATE `users` SET last_activity = now() WHERE user_id=:id", array("id" => $user['user_id']), "post");
+                    $this->model->loginUser($user);
                     redirect('/users');
                 } else {
                     Session::setFlash(getString('CREDENTIALS_NOT_MATCH'), "warning", 1);
@@ -47,7 +42,7 @@ class Users extends Controller
             } else {
                 Session::setFlash("No input received", "danger");
             }
-
+            redirect('/users');
         }
     }
 
@@ -73,7 +68,10 @@ class Users extends Controller
             $data['password'] = password_hash($data['password1'], PASSWORD_DEFAULT);
 
             if($this->model->register($data)){
-                Session::setFlash(getString('REGISTRATION_SUCCESS'), "success", 1);
+              $this->model->loginUser($this->model->getByEmail($data['email']));
+
+              Session::setFlash(getString('REGISTRATION_SUCCESS'), "success", 1);
+              redirect('/users/update');
             }
         }
     }

--- a/app/controllers/api/Users.php
+++ b/app/controllers/api/Users.php
@@ -91,7 +91,8 @@ class Users extends Controller
             } elseif(isset($_POST['change-password'])) {
                 $current_password = $this->model->getUserPassword();
 
-                if ( password_verify($_POST['old-password'], $current_password[0]) ) {
+                // dont demand old password for facebook registered user (until he changes it to valid)
+                if ( $current_password[0] == "no password" || password_verify($_POST['old-password'], $current_password[0]) ) {
                     if ($_POST['new-password'] == $_POST['new-password2']) {
                         if ( $this->model->updatePassword( password_hash($_POST['new-password'], PASSWORD_DEFAULT) ) ) {
                             Session::setFlash(getString('PASSWORD_CHANGED'), 'success');

--- a/app/controllers/web/OauthProvider.php
+++ b/app/controllers/web/OauthProvider.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace app\controllers\web;
+
+use app\controllers\api\OauthProvider as OauthProviderAPIController;
+
+class OauthProvider extends OauthProviderAPIController
+{
+
+}

--- a/app/controllers/web/OauthProvider.php
+++ b/app/controllers/web/OauthProvider.php
@@ -4,7 +4,15 @@ namespace app\controllers\web;
 
 use app\controllers\api\OauthProvider as OauthProviderAPIController;
 
+use app\core\Session;
+
 class OauthProvider extends OauthProviderAPIController
 {
+  public function facebook_disconnect()
+  {
+    $this->model->runQuery("UPDATE `users` SET updated_at = now(), facebook_id = null WHERE user_id=:id", array("id" => Session::get('user_id')), "post");
 
+    Session::setFlash(getString('FACEBOOK_DISCONNECT_SUCCESS'), "success", 1);
+    redirect('/users/update');
+  }
 }

--- a/app/core/Controller.php
+++ b/app/core/Controller.php
@@ -3,6 +3,7 @@
 namespace app\core;
 
 use app\string\Url;
+use app\model\OauthProvider;
 
 
 class Controller {
@@ -106,6 +107,11 @@ class Controller {
           return '/produkty?' . http_build_query($newParams, '', '&');
         });
         $twig->addFunction($stripUrlParam);
+
+        $fburl = new \Twig_SimpleFunction('fbLoginUrl', function($c) {
+          return OauthProvider::fbLoginUrl($c);
+        });
+        $twig->addFunction($fburl);
 
         $this->data['sessionclass'] = new Session;
         $this->data['lang'] = $GLOBALS['lang'];

--- a/app/core/Controller.php
+++ b/app/core/Controller.php
@@ -80,6 +80,7 @@ class Controller {
         });
         $twig->addFunction($buildUrl);
 
+<<<<<<< HEAD
         // removes $params[$remKey] (or $params[$remKey][$remValue]) from $params list
         $stripUrlParam = new \Twig_SimpleFunction('stripUrlParam', function($params, $remKey, $remValue = null) {
           $newParams = [];
@@ -108,6 +109,7 @@ class Controller {
         });
         $twig->addFunction($stripUrlParam);
 
+        // generate facebook oauth url
         $fburl = new \Twig_SimpleFunction('fbLoginUrl', function($c) {
           return OauthProvider::fbLoginUrl($c);
         });

--- a/app/model/OauthProvider.php
+++ b/app/model/OauthProvider.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace app\model;
+
+use app\core\Model;
+use app\core\Session;
+
+class OauthProvider extends Model
+{
+    private $facebook;
+
+    function __construct() {
+      $this->facebook = new Facebook();
+    }
+
+    public static function fbLoginUrl($control) {
+      return (new Facebook())->loginUrl($control);
+    }
+
+    public function  fbCheckUserLogin() {
+      return $this->facebook->checkUserLogin();
+    }
+}
+
+class Facebook
+{
+  private $fbCredentials = [
+  'app_id' => FACEBOOK_APP_ID,
+  'app_secret' => FACEBOOK_APP_SECRET,
+  'default_graph_version' => 'v2.2',
+  ];
+
+  public function loginUrl($control)
+  {
+    $helper = (new \Facebook\Facebook($this->fbCredentials))->getRedirectLoginHelper();
+    return $helper->getLoginUrl('http://vegapo.dev.sk/OauthProvider/'.$control, ['email']);
+  }
+
+  public function checkUserLogin()
+  {
+    try {
+      $fb = new \Facebook\Facebook($this->fbCredentials);
+      $helper = $fb->getRedirectLoginHelper();
+      $accessToken = $helper->getAccessToken();
+    } catch(\Exception $e) {
+      throw new \Exception('Facebook login error: '.$e->getMessage());
+    }
+
+    if (!isset($accessToken)) {
+      if ($this->helper->getError()) {
+        throw new \Exception('Facebook login unauthorized: '.$helper->getError().' - '.$helper->getErrorReason().' ('.$helper->getErrorDescription().')');
+      } else {
+        throw new \Exception('Facebook login bad request.');
+      }
+    }
+
+    try {
+      $response = $fb->get('/me?fields=name,email', $accessToken->getValue());
+    } catch(\Exception $e) {
+      throw new \Exception('Facebook error: '.$e->getMessage());
+    }
+
+    return $response->getGraphUser();
+  }
+}

--- a/app/model/User.php
+++ b/app/model/User.php
@@ -4,6 +4,7 @@ namespace app\model;
 
 use app\core\Model;
 use app\core\Session;
+use app\helper\Redirect;
 
 class User extends Model
 {
@@ -41,10 +42,36 @@ class User extends Model
         return null;
     }
 
+    public function getByFacebookId($id) {
+        $stmt = $this->db->prepare("select * from users where facebook_id = :id LIMIT 1");
+        $stmt->execute(array(':id' => $id));
+        if ($results = $stmt->fetch()) {
+            return $results;
+        }
+        return null;
+    }
+
     public function register($data) {
         $sql = "INSERT INTO users (username, email, password, country, role) VALUES(:username,:email,:password,:country,:role)";
         $params = array("username" => $data['username'], "email" => $data['email'], "password" => $data['password'], "country" => COUNTRY_CODE, "role" => 4 );
         return $this->runQuery($sql, $params, "post");
+    }
+
+    // user session login
+    public function loginUser($user)
+    {
+      Session::set('user_id', $user['user_id']);
+      Session::set('user_role', $user['role']);
+      Session::set('user_country', $user['country']);
+      Session::set('username', $user['username']);
+      $this->runQuery("UPDATE `users` SET last_activity = now() WHERE user_id=:id", array("id" => $user['user_id']), "post");
+    }
+
+    // user session logout
+    public static function logoutUser()
+    {
+        Session::destroy();
+        Redirect::toURL("LOGIN");
     }
 
     public function getUserPassword(){
@@ -107,7 +134,7 @@ class User extends Model
         $sql = "DELETE FROM `forgotten_password` WHERE `created_at` < ADDDATE(NOW(), INTERVAL -1 HOUR)";
         $this->runQuery($sql, [], 'post');
 
-        // check token 
+        // check token
         $sql = "SELECT * FROM forgotten_password WHERE user_id = :user_id AND token = :token";
         $params = array(
             'user_id'   =>      $user_id,
@@ -125,7 +152,7 @@ class User extends Model
 
     public function getList()
     {
-        $sql = "SELECT u.user_id, u.username, COUNT(p.id) numberOfProducts, u.country from users u 
+        $sql = "SELECT u.user_id, u.username, COUNT(p.id) numberOfProducts, u.country from users u
                 LEFT JOIN products p ON p.author_id = u.user_id
                 WHERE p.visibility = 1
                 GROUP BY u.user_id

--- a/app/model/User.php
+++ b/app/model/User.php
@@ -86,7 +86,8 @@ class User extends Model
     public function updatePassword($password, $session = null) {
 
         if (!$session) {
-            Session::get('user_id');
+            // bug?
+            $session = Session::get('user_id');
         }
         $stmt = $this->db->prepare("UPDATE users SET password = :password, updated_at = now() WHERE user_id = :id");
         $stmt->execute(array(

--- a/app/string/Url.php
+++ b/app/string/Url.php
@@ -26,6 +26,7 @@ class Url
 	'LOGIN' => "/users/login",
 	'ADMIN' => "/admin/",
 	'INDEX' => "/",
+  'REGISTER' => "/users/register",
 
 
 	'SUPERMARKET_ADMIN_DELETE' => "/admin/obchody/vymazat/",

--- a/app/string/lang/cz.php
+++ b/app/string/lang/cz.php
@@ -101,4 +101,11 @@ $cz = [
 
     "WARRNING_MISSING_SUPERMARKET_OR_CATEGORY" => "Prosím, vytvořte obchod a kategorii před přidáním produktu",
 
+    "FACEBOOK_LOGIN"            => "pomocí Facebook účtu",
+    "FACEBOOK_REGISTER"         => "pomocí Facebook účtu",
+    "FACEBOOK_CONNECT"          => "Připoj Facebook účet",
+    "FACEBOOK_DISCONNECT"       => "Odpoj Facebook účet",
+
+    "MISSING_PASSWORD"        => "Pro Váš účet není zadáno žádné heslo. Pokud se chcete přihlásit emailem, zadejte prosím heslo.",
+
     ];

--- a/app/string/lang/sk.php
+++ b/app/string/lang/sk.php
@@ -34,7 +34,7 @@ $sk = [
     "DENIED"                    =>  "Zamietnuté",
     "WAITING"                   =>  "Čaká",
 
-    
+
 
     'ABOUT' 					=> "O",
     'ABOUT_PROJECT' 			=> "O projekte",
@@ -175,5 +175,18 @@ $sk = [
 
     "USER_FUNCTIONS"            => "Užívateľské funkcie",
 
+    "FACEBOOK_LOGIN"            => "pomocou Facebook účtu",
+    "FACEBOOK_LOGIN_SUCCESS"    => "Prihlásenie pomocou Facebook účtu úspešné",
+    "FACEBOOK_LOGIN_ERROR"      => "Chyba prihlásenia pomocou Facebook účtu",
+    "FACEBOOK_REGISTER"         => "pomocou Facebook účtu",
+    "FACEBOOK_REGISTER_SUCCESS" => "Registrácia pomocou Facebook účtu úspešná",
+    "FACEBOOK_REGISTER_ERROR"   => "Chyba registrácie pomocou Facebook účtu",
+    "FACEBOOK_CONNECT"          => "Pripoj Facebook účet",
+    "FACEBOOK_CONNECTN_SUCCESS" => "Pripojenie Facebook účtu úspešné",
+    "FACEBOOK_CONNECT_ERROR"    => "Chyba pripojenie Facebook účtu",
+    "FACEBOOK_DISCONNECT"       => "Odpoj Facebook účet",
+    "FACEBOOK_DISCONNECT_SUCCESS" => "Odpojenie Facebook účtu úspešné",
+
+    "MISSING_PASSWORD"        => "Pre Váš účet nie je zadané heslo. Ak sa chcete prihlásiť aj pomocou emailu prosím zadajte heslo.",
 
  ];

--- a/app/view/web/modal/login.twig
+++ b/app/view/web/modal/login.twig
@@ -23,7 +23,7 @@
             <button type="submit" class="btn btn-primary">{{ lang.SUBMIT }}</button>
         </form>
         <br>
-              <a class="btn btn-primary" href="{{ fbLoginUrl('fb_login_callback') }}">facebook login</a>
+              <a class="btn btn-primary" href="{{ fbLoginUrl('fb_login_callback') }}">{{ lang.FACEBOOK_LOGIN }}</a>
             </div>
         </div>
     </div>

--- a/app/view/web/modal/login.twig
+++ b/app/view/web/modal/login.twig
@@ -23,7 +23,7 @@
             <button type="submit" class="btn btn-primary">{{ lang.SUBMIT }}</button>
         </form>
         <br>
-              <a href="{{ fbLoginUrl('fb_login_callback') }}">facebook login</a>
+              <a class="btn btn-primary" href="{{ fbLoginUrl('fb_login_callback') }}">facebook login</a>
             </div>
         </div>
     </div>

--- a/app/view/web/modal/login.twig
+++ b/app/view/web/modal/login.twig
@@ -23,7 +23,7 @@
             <button type="submit" class="btn btn-primary">{{ lang.SUBMIT }}</button>
         </form>
         <br>
-              
+              <a href="{{ fbLoginUrl('fb_login_callback') }}">facebook login</a>
             </div>
         </div>
     </div>

--- a/app/view/web/modal/register.twig
+++ b/app/view/web/modal/register.twig
@@ -35,7 +35,7 @@
                     <button type="submit" class="btn btn-primary">{{ lang.SUBMIT }}</button>
                 </form>
         <br>
-              <a href="{{ fbLoginUrl('fb_register_callback') }}">facebook register</a>
+              <a class="btn btn-primary" href="{{ fbLoginUrl('fb_register_callback') }}">facebook register</a>
             </div>
         </div>
     </div>

--- a/app/view/web/modal/register.twig
+++ b/app/view/web/modal/register.twig
@@ -35,7 +35,7 @@
                     <button type="submit" class="btn btn-primary">{{ lang.SUBMIT }}</button>
                 </form>
         <br>
-              <a class="btn btn-primary" href="{{ fbLoginUrl('fb_register_callback') }}">facebook register</a>
+              <a class="btn btn-primary" href="{{ fbLoginUrl('fb_register_callback') }}">{{ lang.FACEBOOK_REGISTER }}</a>
             </div>
         </div>
     </div>

--- a/app/view/web/modal/register.twig
+++ b/app/view/web/modal/register.twig
@@ -35,7 +35,7 @@
                     <button type="submit" class="btn btn-primary">{{ lang.SUBMIT }}</button>
                 </form>
         <br>
-              
+              <a href="{{ fbLoginUrl('fb_register_callback') }}">facebook register</a>
             </div>
         </div>
     </div>

--- a/app/view/web/users/index.twig
+++ b/app/view/web/users/index.twig
@@ -4,6 +4,10 @@
 
 <section id="main">
     <div class="container">
+        {# nevadi? #}
+        <div class="text-center">
+          {{ include('web/modules/flash.twig') }}
+        </div>
         <div class="row">
             <div class="col-md-9 text-center">
                 <h2 class="margin-top-0 wow fadeIn">{{ lang.GREETING }} {{session.username}}</h2>
@@ -13,7 +17,7 @@
             	<div class="col-md-auto">
 
                     <div class="list-group">
-                      <a href="/produkty/pridat" class="list-group-item list-group-item-action">{{ lang.PRODUCT_NEW }}</a> 
+                      <a href="/produkty/pridat" class="list-group-item list-group-item-action">{{ lang.PRODUCT_NEW }}</a>
                       <a href="/users/update" class="list-group-item list-group-item-action">{{ lang.PROFILE_EDIT }}</a>
                       <a href="/produkty?oblubene={{ session.user_id }}" class="list-group-item list-group-item-action">{{ lang.FAVOURITES }}</a>
                       <a href="/produkty?autor={{ session.user_id }}" class="list-group-item list-group-item-action">{{ lang.PRODUCTS_MY }}</a>
@@ -26,7 +30,7 @@
             	</div>
 
             </div>
-            
+
         </div>
     </div>
 </section>

--- a/app/view/web/users/login.twig
+++ b/app/view/web/users/login.twig
@@ -7,7 +7,7 @@
     <header id="main">
     <div class="container">
         <div class="inner">
-{{ include('web/modules/flash.twig') }}  
+{{ include('web/modules/flash.twig') }}
       <div class="row">
                 <div class="col-md-12">
                     <h1>{{ lang.LOGIN }}</h1>

--- a/app/view/web/users/update.twig
+++ b/app/view/web/users/update.twig
@@ -9,7 +9,7 @@
         <div class="wow fadeInUp text-center"><h2 class="display-4">{{ lang.PROFILE_EDIT }}</h2></div>
         <hr>
         <div class="text-center">
-            {{ include('web/modules/flash.twig') }}  
+            {{ include('web/modules/flash.twig') }}
         </div>
 
     <div class="row">
@@ -45,7 +45,10 @@
                 <button type="submit" name="change-details" class="btn btn-primary">{{ lang.SUBMIT }}</button>
             </form>
             <br>
+            <a href="{{ fbLoginUrl('fb_connect_callback') }}">connect facebook</a>
         </div>
+        {# facebook registered users can not change their password - for now #}
+        {% if not user.facebook_id %}
         <div class="col-md-5 offset-md-1">
             <h3 class="h3 text-center">{{ lang.PASSWORD_CHANGE }}</h3>
             <hr>
@@ -68,6 +71,7 @@
                 <button type="submit" name="change-password" class="btn btn-primary">{{ lang.SUBMIT }}</button>
             </form>
         </div>
+        {% endif %}
 
     </div>
 </div>

--- a/app/view/web/users/update.twig
+++ b/app/view/web/users/update.twig
@@ -45,7 +45,7 @@
                 <button type="submit" name="change-details" class="btn btn-primary">{{ lang.SUBMIT }}</button>
             </form>
             <br>
-            <a href="{{ fbLoginUrl('fb_connect_callback') }}">connect facebook</a>
+            <a class="btn btn-primary" href="{{ fbLoginUrl('fb_connect_callback') }}">connect facebook</a>
         </div>
         {# facebook registered users can not change their password - for now #}
         {% if not user.facebook_id %}

--- a/app/view/web/users/update.twig
+++ b/app/view/web/users/update.twig
@@ -47,17 +47,18 @@
             <br>
             <a class="btn btn-primary" href="{{ fbLoginUrl('fb_connect_callback') }}">connect facebook</a>
         </div>
-        {# facebook registered users can not change their password - for now #}
-        {% if not user.facebook_id %}
+
         <div class="col-md-5 offset-md-1">
             <h3 class="h3 text-center">{{ lang.PASSWORD_CHANGE }}</h3>
             <hr>
             <form method="post" action="" id="password-update">
+                {# facebook registered user does not initially have a valid password #}
+                {% if user.password != "no password" %}
                 <div class="form-group">
                     <label for="old-password">{{ lang.PASSWORD_OLD }}</label>
                     <input type="password" class="form-control" id="old-password" name="old-password" >
                 </div>
-
+                {% endif %}
                 <div class="form-group">
                     <label for="new-password">{{ lang.PASSWORD_NEW }}</label>
                     <input type="password" class="form-control" id="new-password" name="new-password" >
@@ -71,7 +72,6 @@
                 <button type="submit" name="change-password" class="btn btn-primary">{{ lang.SUBMIT }}</button>
             </form>
         </div>
-        {% endif %}
 
     </div>
 </div>

--- a/app/view/web/users/update.twig
+++ b/app/view/web/users/update.twig
@@ -45,7 +45,12 @@
                 <button type="submit" name="change-details" class="btn btn-primary">{{ lang.SUBMIT }}</button>
             </form>
             <br>
-            <a class="btn btn-primary" href="{{ fbLoginUrl('fb_connect_callback') }}">connect facebook</a>
+            {#facebook aouth functionality #}
+            {% if not user.facebook_id %}
+                <a class="btn btn-primary" href="{{ fbLoginUrl('fb_connect_callback') }}">{{ lang.FACEBOOK_CONNECT }}</a>
+            {% elseif  user.password != "no password" %}
+                <a class="btn btn-primary" href="/OauthProvider/facebook_disconnect">{{ lang.FACEBOOK_DISCONNECT }}</a>
+            {% endif %}
         </div>
 
         <div class="col-md-5 offset-md-1">
@@ -58,6 +63,8 @@
                     <label for="old-password">{{ lang.PASSWORD_OLD }}</label>
                     <input type="password" class="form-control" id="old-password" name="old-password" >
                 </div>
+                {% else %}
+                  {{ lang.MISSING_PASSWORD }}
                 {% endif %}
                 <div class="form-group">
                     <label for="new-password">{{ lang.PASSWORD_NEW }}</label>

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,8 @@
         "twig/twig": "^2.0",
         "phpmailer/phpmailer": "^5.2",
         "filp/whoops": "^2.1",
-        "intervention/image": "^2.3"
+        "intervention/image": "^2.3",
+        "facebook/graph-sdk": "^5.6"
     },
 
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "c5ff5a38671828932cedfc948f39721c",
+    "content-hash": "1e816f83cf2e5b0d57f55934f128f7a1",
     "packages": [
         {
             "name": "erusev/parsedown",
@@ -47,6 +47,64 @@
                 "parser"
             ],
             "time": "2017-03-29T16:04:15+00:00"
+        },
+        {
+            "name": "facebook/graph-sdk",
+            "version": "5.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/facebook/php-graph-sdk.git",
+                "reference": "2f9639c15ae043911f40ffe44080b32bac2c5280"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/facebook/php-graph-sdk/zipball/2f9639c15ae043911f40ffe44080b32bac2c5280",
+                "reference": "2f9639c15ae043911f40ffe44080b32bac2c5280",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.4|^7.0"
+            },
+            "require-dev": {
+                "guzzlehttp/guzzle": "~5.0",
+                "mockery/mockery": "~0.8",
+                "phpunit/phpunit": "~4.0"
+            },
+            "suggest": {
+                "guzzlehttp/guzzle": "Allows for implementation of the Guzzle HTTP client",
+                "paragonie/random_compat": "Provides a better CSPRNG option in PHP 5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Facebook\\": "src/Facebook/"
+                },
+                "files": [
+                    "src/Facebook/polyfills.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Facebook Platform"
+            ],
+            "authors": [
+                {
+                    "name": "Facebook",
+                    "homepage": "https://github.com/facebook/php-graph-sdk/contributors"
+                }
+            ],
+            "description": "Facebook SDK for PHP",
+            "homepage": "https://github.com/facebook/php-graph-sdk",
+            "keywords": [
+                "facebook",
+                "sdk"
+            ],
+            "time": "2017-08-16T17:28:07+00:00"
         },
         {
             "name": "filp/whoops",


### PR DESCRIPTION
Popis v #7 

v configu je potrebna nastavit 

``` php
define("FACEBOOK_APP_ID", '...');
define("FACEBOOK_APP_SECRET", '...');
```
a na developers.facebook updatnut/vytvorit app konto, najma v nastaveniach facebook loginu pridat vegapo medzi povolene uri. Pre urychlenie testu mozem poslat moje autentifikacne udaje.

Zakladom funkcionality je `OauthProvider` (zatial len pre fb ale nebol by problem pridat dalsie moznosti ak by bol zaujem) ktory generuje/kontroluje oauth requesty (pouzitim [facebook/php-graph-sdk](https://github.com/facebook/php-graph-sdk)).
Naparovanie konta s fb uctom je ukladane do `users.facebook_id`. Po sparovani uctov je aj nadalej mozne hlasit sa mail/heslo sposobom (musel som trocha upravit povodnu funkcionalitu aby dovolila updatenut heslo aj pre cez fb registrovaneho uzivatela).
Zatial asi vsetko, kludne sa pytaj na cokolvek.